### PR TITLE
fixes #568

### DIFF
--- a/app/js/arethusa.util/generator.js
+++ b/app/js/arethusa.util/generator.js
@@ -87,10 +87,9 @@ angular.module('arethusa.util').service('generator', [
 
           var trsl, hint;
 
-          scope.$on('keysAdded', function(_, keys) {
-            var sel = keys.history;
-            if (sel) {
-              hint = aU.formatKeyHint(sel[type]);
+          scope.$watch('history.activeKeys', function(newVal, oldVal) {
+            if (newVal) {
+              hint = aU.formatKeyHint(newVal[type]);
               setTitle();
             }
           });


### PR DESCRIPTION
use scope.$watch rather than scope.$on to watch for registration of shortcut keys because the rootScope on which the keysAdded event is broadcast isn't available to the directive.