### PR TITLE
Reactivate `newer` and fix problems with util

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -190,8 +190,8 @@ function arethusaCopy() {
 
 function uglifyTasks() {
   var res = [
-    'ngtemplates',
-    'concat',
+    'newer:ngtemplates',
+    'newer:concat',
   ];
 
   // We don't need newer for copy - the overhead of asking
@@ -217,7 +217,10 @@ function arethusaTemplates() {
   };
 
   eachModule(function(module) {
-    obj[toJsScript(module)] = templateObj(module);
+    // arethusa.util does not come with templates
+    if (module != 'arethusa.util') {
+      obj[toJsScript(module)] = templateObj(module);
+    }
   });
 
   return obj;


### PR DESCRIPTION
I was recently experiencing problems with the `ngtemplates` grunt task,
which aborted the server tasks, because `arethusa.util` does not come
with any templates whatsoever.

I formerly thought this was limited to my desktop machine - something
weird going on with the caching of `grunt-newer`, but as @balmas also
experienced this, we finally have to take measures to prevent this
altogether.

The fix is simple: We just don't add an `ngtemplates:arethusaUtil` task.