### PR TITLE
Analytics error events

### DIFF
--- a/app/js/arethusa.core/arethusa_ctrl.js
+++ b/app/js/arethusa.core/arethusa_ctrl.js
@@ -1,5 +1,6 @@
 'use strict';
 angular.module('arethusa.core').controller('ArethusaCtrl', [
+  'GlobalErrorHandler',
   '$scope',
   'configurator',
   'state',
@@ -11,7 +12,7 @@ angular.module('arethusa.core').controller('ArethusaCtrl', [
   'translator',
   '$timeout',
   'globalSettings',
-  function ($scope, configurator, state, documentStore, notifier,
+  function (GlobalErrorHandler, $scope, configurator, state, documentStore, notifier,
             saver, history, plugins, translator, $timeout, globalSettings) {
     // This is the entry point to the application.
 

--- a/app/js/arethusa/global_error_handler.js
+++ b/app/js/arethusa/global_error_handler.js
@@ -6,9 +6,11 @@ angular.module('arethusa').factory('GlobalErrorHandler', [
   function($window, $analytics) {
     var oldErrorHandler = $window.onerror;
     $window.onerror = function errorHandler(errorMessage, url, lineNumber) {
+      var trace = printStackTrace();
       $analytics.eventTrack(errorMessage + " @" + url + " : " + lineNumber, {
-        category: 'error', label: errorMessage
+        category: 'error', label: trace.join(', ')
       });
+
       if (oldErrorHandler)
         return oldErrorHandler(errorMessage, url, lineNumber);
 

--- a/app/js/arethusa/global_error_handler.js
+++ b/app/js/arethusa/global_error_handler.js
@@ -21,10 +21,11 @@ angular.module('arethusa').factory('$exceptionHandler', [
   '$analytics',
   '$log',
   function($analytics, $log) {
-    return function(exception, cause) {
+    return function errorHandler(exception, cause) {
       $log.error.apply($log, arguments);
-      $analytics.eventTrack(exception + ": " + cause, {
-        category: 'error', label: exception
+      var trace = printStackTrace();
+      $analytics.eventTrack(exception + ': ' + cause, {
+        category: 'error', label: trace.join(', ')
       });
     };
   }

--- a/app/js/arethusa/global_error_handler.js
+++ b/app/js/arethusa/global_error_handler.js
@@ -1,0 +1,18 @@
+"use strict";
+
+angular.module('arethusa').factory('GlobalErrorHandler', [
+  '$window',
+  '$analytics',
+  function($window, $analytics) {
+    var oldErrorHandler = $window.onerror;
+    $window.onerror = function errorHandler(errorMessage, url, lineNumber) {
+      $analytics.eventTrack(errorMessage + " @" + url + " : " + lineNumber, {
+        category: 'error', label: errorMessage
+      });
+      if (oldErrorHandler)
+        return oldErrorHandler(errorMessage, url, lineNumber);
+
+      return false;
+    };
+  }
+]);

--- a/app/js/arethusa/global_error_handler.js
+++ b/app/js/arethusa/global_error_handler.js
@@ -16,3 +16,16 @@ angular.module('arethusa').factory('GlobalErrorHandler', [
     };
   }
 ]);
+
+angular.module('arethusa').factory('$exceptionHandler', [
+  '$analytics',
+  '$log',
+  function($analytics, $log) {
+    return function(exception, cause) {
+      $log.error.apply($log, arguments);
+      $analytics.eventTrack(exception + ": " + cause, {
+        category: 'error', label: exception
+      });
+    };
+  }
+]);


### PR DESCRIPTION
Create google analytics events for all exceptions. The category is always `error`, the action is the error message including the cause and the label is the stack trace.
Normal error handling is resumed after the event has been posted.