### PR TITLE
Fix & handling in labelSelector

### DIFF
--- a/app/js/arethusa.relation/directives/label_selector.js
+++ b/app/js/arethusa.relation/directives/label_selector.js
@@ -19,7 +19,7 @@ angular.module('arethusa.relation').directive('labelSelector', [
         });
 
         scope.$on('nestedMenuSelection', function(event, obj) {
-          if (angular.isFunction(scope.change)) {
+          if (attrs.change && angular.isFunction(scope.change)) {
             scope.change();
           } else {
             var oldAncestors = angular.copy(obj.ancestors);


### PR DESCRIPTION
Introduced in 3dc5bc543444c4001be48026f34bb2ac0a939213, this uncovers
something which seems a bit of an unforunate decision with the angular
code.
Whenever you define & in an isolate scope, angular will **always**
return the wrapper function to evaluate this in the parent scope. This
means that even when this attribute is not defined at all, the scope
variable will be set to a function.

To make the check we want to, we look if the attribute contains a truthy
expression now.

Fixes #573 