### PR TITLE
Fix download of documents

### DIFF
--- a/app/js/arethusa.core/directives/outputter.js
+++ b/app/js/arethusa.core/directives/outputter.js
@@ -58,7 +58,12 @@ angular.module('arethusa.core').directive('outputterItem', [
           var fileName = scope.obj.identifier + '.' + scope.obj.fileType;
           downloader.setAttribute('href', createUrl(blob));
           downloader.setAttribute('download', fileName);
+
+          // Firefox cannot handle the click event correctly when the element
+          // is not attached to the DOM - we therefore hack this temporarily
+          document.body.appendChild(downloader);
           downloader.click();
+          document.body.removeChild(downloader);
         };
       },
       templateUrl: 'templates/arethusa.core/outputter_item.html',

--- a/app/js/arethusa.core/directives/outputter.js
+++ b/app/js/arethusa.core/directives/outputter.js
@@ -28,7 +28,12 @@ angular.module('arethusa.core').directive('outputter', [
 ]);
 
 angular.module('arethusa.core').directive('outputterItem', [
-  function() {
+  '$window',
+  function($window) {
+    function createUrl(blob) {
+      return ($window.URL || $window.webkitURL).createObjectURL(blob);
+    }
+
     return {
       restrict: 'A',
       link: function(scope, element, attrs) {
@@ -49,10 +54,9 @@ angular.module('arethusa.core').directive('outputterItem', [
         var downloader;
         scope.download = function() {
           if (!downloader) downloader = document.createElement('a');
-          var str = encodeURIComponent(scope.data());
-          var type = 'data:' + scope.obj.mimeType + ' ;charset=utf-8,';
+          var blob = new Blob([scope.data()], { type: scope.obj.mimeType + ';charset=utf-8'});
           var fileName = scope.obj.identifier + '.' + scope.obj.fileType;
-          downloader.setAttribute('href', type + str);
+          downloader.setAttribute('href', createUrl(blob));
           downloader.setAttribute('download', fileName);
           downloader.click();
         };

--- a/app/js/arethusa.core/directives/outputter.js
+++ b/app/js/arethusa.core/directives/outputter.js
@@ -54,6 +54,13 @@ angular.module('arethusa.core').directive('outputterItem', [
         var downloader;
         scope.download = function() {
           if (!downloader) downloader = document.createElement('a');
+
+          // This should detect that Safari is used...
+          if (!angular.isDefined(downloader.download)) {
+            /* global alert */
+            alert("Your browser does not support this feature - use Chrome, Firefox or Opera");
+            return;
+          }
           var blob = new Blob([scope.data()], { type: scope.obj.mimeType + ';charset=utf-8'});
           var fileName = scope.obj.identifier + '.' + scope.obj.fileType;
           downloader.setAttribute('href', createUrl(blob));


### PR DESCRIPTION
Not all browsers support the `download` attribute natively, we have to use `Blob`s.

Unfortunately this will not work for Safari users - only Apple is to blame for this.

TODO: Confirm that Safari users get an alert.

Fixes #581 
