### PR TITLE
Staging switch

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -339,7 +339,7 @@ module.exports = function(grunt) {
       options: {
         jshintrc: true,
       },
-      all: ['*.js', srcFiles, specFiles]
+      all: ['*.js', srcFiles, specFiles, './dist/i18n/*.json']
     },
     karma: {
       spec: {

--- a/app/css/arethusa.scss
+++ b/app/css/arethusa.scss
@@ -937,6 +937,14 @@ code {
   }
 }
 
+.relocate-item {
+  padding-left: 0;
+  color: #3E8D9C;
+}
+.relocate-item:hover {
+  color: #73CDDE;
+}
+
 .search-result-hovered {
   background-color: #C8E5FF;
   @include transition(background-color 50ms ease-in);

--- a/app/js/arethusa.core/directives/relocate.js
+++ b/app/js/arethusa.core/directives/relocate.js
@@ -1,0 +1,35 @@
+"use strict";
+
+/**
+ * @ngdoc directive
+ * @name arethusa.core.directives:relocate
+ * @restrict A
+ *
+ * @description
+ * display a list of one or more locations each of which triggers
+ * a click event which triggers
+ * {@link arethusa.core.relocateHandler#methods_relocate relocateHandler#relocate},
+ * when one or more relocate url is defined in the {@link arethusa.core.relocateHandler relocateHandler},
+ *
+ * @requires arethusa.core.relocateHandler
+ * @requires arethusa.core.translator
+ */
+angular.module('arethusa.core').directive('relocate', [
+  'relocateHandler',
+  'translator',
+  function(relocateHandler, translator) {
+    return {
+      restrict: 'A',
+      scope: {},
+      link: function(scope, element, attrs) {
+        if (relocateHandler.defined) {
+          scope.locations = relocateHandler.locations;
+          scope.relocate = function(loc) {
+              relocateHandler.relocate(loc);
+            };
+        } 
+      },
+      templateUrl: 'templates/arethusa.core/relocate.html'
+    };
+  }
+]);

--- a/app/js/arethusa.core/relocate_handler.js
+++ b/app/js/arethusa.core/relocate_handler.js
@@ -1,0 +1,73 @@
+"use strict";
+
+/**
+ * @ngdoc service
+ * @name arethusa.core.relocateHandler
+ *
+ * @description
+ * Allows relocating between base deployments of the application
+ *
+ * Needs to be defined in a configuration file and uses the following format
+ *
+ * ```
+ *   "relocateHandler" : {
+ *     "location1": {
+ *       "baseUrl" : "http path to the base deployment location"
+ *     },
+ *      ...
+ *     "locationN": {
+ *       "baseUrl" : "http path to the base deployment location"
+ *      }
+ *   }
+ * ```
+ *
+ * @requires $location
+ * @requires $window
+ * @requires arethusa.core.configurator
+ *
+ */
+
+angular.module('arethusa.core').service('relocateHandler', [
+  "$location",
+  "$window",
+  "configurator",
+  "$analytics",
+  function($location, $window, configurator, $analytics) {
+    var self = this;
+
+
+    var conf = configurator.configurationFor('relocateHandler') || {};
+
+    // when it's not configured, we don't do anything
+    this.defined = !angular.equals({}, conf);
+    this.locations = this.defined ? Object.keys(conf) : [];
+
+    function relocateUrl(key) {
+      var base = conf[key].baseUrl;
+      debugger;
+      var currentUrl = $location.url();
+      return base + currentUrl;
+    }
+
+
+    /**
+     * @ngdoc function
+     * @name arethusa.core:relocateHandler#relocate
+     * @methodOf arethusa.core.relocateHandler
+     *
+     * @description
+     * Relocates arethusa to the configured base url
+     *
+     * @param {string} loc The key to the location.
+     * @param {string} [targetWin='_self'] The target window.
+     */
+    this.relocate = function(loc,targetWin) {
+      $analytics.eventTrack('relocate', {
+        category: 'actions', label: 'relocate'
+      });
+
+      targetWin = targetWin || '_self';
+      $window.open(relocateUrl(loc), targetWin);
+    };
+  }
+]);

--- a/app/js/arethusa.core/relocate_handler.js
+++ b/app/js/arethusa.core/relocate_handler.js
@@ -60,9 +60,9 @@ angular.module('arethusa.core').service('relocateHandler', [
      * @param {string} loc The key to the location.
      * @param {string} [targetWin='_self'] The target window.
      */
-    this.relocate = function(loc,targetWin) {
+    this.relocate = function(loc, targetWin) {
       $analytics.eventTrack('relocate', {
-        category: 'actions', label: 'relocate'
+        category: 'actions', label: loc
       });
 
       targetWin = targetWin || '_self';

--- a/app/js/arethusa.core/relocate_handler.js
+++ b/app/js/arethusa.core/relocate_handler.js
@@ -44,7 +44,6 @@ angular.module('arethusa.core').service('relocateHandler', [
 
     function relocateUrl(key) {
       var base = conf[key].baseUrl;
-      debugger;
       var currentUrl = $location.url();
       return base + currentUrl;
     }

--- a/app/static/configs/perseids.json
+++ b/app/static/configs/perseids.json
@@ -132,6 +132,12 @@
     "@include" : "exit_handler/perseids.json"
   },
 
+  "relocateHandler" : {
+    "staging" :  {
+      "baseUrl" : "http://www.perseids.org/tools/arethusa_staging/app/#"
+     }
+  },
+
   "keyCapture" : {
     "@include" : "keyboard/key_map.json"
   }

--- a/app/templates/arethusa.core/help_panel.html
+++ b/app/templates/arethusa.core/help_panel.html
@@ -73,7 +73,11 @@
             <tr>
               <td translate="date"/>
               <td>{{ vers.date | date: 'medium' }}</td>
+            </tr>
             <tr>
+              <td translate="relocateHandler.title"/>
+              <td relocate/>
+            </tr>
           </table>
         </li>
       </ul>

--- a/app/templates/arethusa.core/help_panel.html
+++ b/app/templates/arethusa.core/help_panel.html
@@ -49,7 +49,7 @@
       </ul>
     </div>
 
-    <div help-panel-item toggler="about" heading="helpPanel.about" height="100px">
+    <div help-panel-item toggler="about" heading="helpPanel.about" height="160px">
       <ul class="no-list">
         <li>
           <table class="small">

--- a/app/templates/arethusa.core/relocate.html
+++ b/app/templates/arethusa.core/relocate.html
@@ -1,0 +1,6 @@
+<ul ng-if="locations" class="no-list">
+  <li class="relocate-item" ng-repeat="location in locations" ng-click="relocate(location)">
+    {{ location }}
+  </li>
+</ul>
+<div ng-if="!locations" translate="relocateHandler.noLocations"/>

--- a/dist/i18n/de.json
+++ b/dist/i18n/de.json
@@ -166,6 +166,7 @@
       "start": "Aussteigen zu"
     }
   },
+  "relocateHandler": { },
   "errorDialog": {
    "close" : "Schließen",
   },

--- a/dist/i18n/de.json
+++ b/dist/i18n/de.json
@@ -166,7 +166,10 @@
       "start": "Aussteigen zu"
     }
   },
-  "relocateHandler": { },
+  "relocateHandler": {
+    "title" : "Alternative Versionen",
+    "noLocations" : "Nicht verfügbar"
+  },
   "errorDialog": {
    "close" : "Schließen",
   },

--- a/dist/i18n/de.json
+++ b/dist/i18n/de.json
@@ -171,7 +171,7 @@
     "noLocations" : "Nicht verfügbar"
   },
   "errorDialog": {
-   "close" : "Schließen",
+   "close" : "Schließen"
   },
   "relation": {
     "changeAll": "Alle verändern",

--- a/dist/i18n/en.json
+++ b/dist/i18n/en.json
@@ -167,6 +167,10 @@
       "end": ""
     }
   },
+  "relocateHandler": {
+    "title" : "Alternate Versions",
+    "noLocations" : "N/A"
+  },
   "errorDialog": {
    "close" : "Close",
    "sendMessage" : "Type description of what you were doing here.",

--- a/dist/i18n/fr.json
+++ b/dist/i18n/fr.json
@@ -153,6 +153,7 @@
   "exitHandler": {
     "exitTo": {}
   },
+  "relocateHandler": { },
   "errorDialog": {
     "close" : "Fermer",
   },

--- a/dist/i18n/fr.json
+++ b/dist/i18n/fr.json
@@ -155,7 +155,7 @@
   },
   "relocateHandler": { },
   "errorDialog": {
-    "close" : "Fermer",
+    "close" : "Fermer"
   },
   "relation": {
     "changeAll": "Changer tout",

--- a/dist/i18n/it.json
+++ b/dist/i18n/it.json
@@ -31,6 +31,7 @@
   "exitHandler": {
     "exitTo": {}
   },
+  "relocateHandler": { },
   "errorDialog": {},
   "relation": {},
   "comments": {}


### PR DESCRIPTION
This is not the most beautiful or full-featured implementation, but I hope it will do for now. The idea is just to provide a quick way for users to access the staging environment to help us test and try out new features.  

In a ideal world, I would have implemented this in a way that is a little more robust ...e .g. some better things to do would be:
- check to be sure the current url is not the same as the relocate url
- allow for an alternate config file specified for the relocate environment 
- make the relocate directive more self contained and not deployed in the help menu but as a nav bar icon, etc.  

But I don't have a lot of time to put into it right now and really need this deployed on Perseids ASAP.

As currently coded, we'll just have to have different versions of the perseids.json conf file in the deployment branch and in the master branch to have different configurations for the relocation handler for each.  

@Christof @LFDM if either of you want to give me the nod to go ahead with it as-is over the weekend, I would very much appreciate it. If not, I will do without :) My plan is to merge and deploy on Monday 19 January first in this branch, and then master (deploying master to staging on Perseids)