### PR TITLE
Trigger a full page reload on route changes

### DIFF
--- a/app/js/arethusa.core/arethusa_ctrl.js
+++ b/app/js/arethusa.core/arethusa_ctrl.js
@@ -11,8 +11,9 @@ angular.module('arethusa.core').controller('ArethusaCtrl', [
   'translator',
   '$timeout',
   'globalSettings',
-  function ($scope, configurator, state, documentStore, notifier,
-            saver, history, plugins, translator, $timeout, globalSettings) {
+  'routeChangeWatcher',
+  function ($scope, configurator, state, documentStore, notifier, saver, history,
+            plugins, translator, $timeout, globalSettings, routeChangeWatcher) {
     // This is the entry point to the application.
 
     var translations = translator(['loadInProgress', 'loadComplete']);

--- a/app/js/arethusa.core/route_change_watcher.js
+++ b/app/js/arethusa.core/route_change_watcher.js
@@ -1,0 +1,11 @@
+"use strict";
+
+angular.module('arethusa.core').service('routeChangeWatcher', [
+  '$rootScope',
+  '$window',
+  function($rootScope, $window) {
+    $rootScope.$on('$locationChangeSuccess', function() {
+      $window.location.reload();
+    });
+  }
+]);

--- a/spec/arethusa.core/arethusa_ctrl_spec.js
+++ b/spec/arethusa.core/arethusa_ctrl_spec.js
@@ -26,7 +26,8 @@ describe('ArethusaCtrl', function() {
       history: arethusaMocks.history(),
       plugins: arethusaMocks.plugins(),
       globalSettings: globalSettings,
-      translator: function() {}
+      translator: function() {},
+      routeChangeWatcher: function() {}
     };
 
     var ctrl = $controller('ArethusaCtrl', mainCtrlInits);


### PR DESCRIPTION
We have troubles with our state-holding services when the route is
changing and therefore trigger a full page reload, so that every single
angular instance is blasted and reloaded.

Closes #592
Closes #514 

Mind what's happening here: We just inject the `routeChangeWatcher` into the `ArethusaCtrl`, but do not have to call a function of it - injecting the service makes sure the service is instantiated (angular calls `new` on it behind the scenes). Inside it constructor it's just defining a listener for route changes, so we're all good without further changes.