### PR TITLE
Collected plugins

### DIFF
--- a/app/css/_collected_plugin_settings.scss
+++ b/app/css/_collected_plugin_settings.scss
@@ -1,0 +1,18 @@
+table.plugin-settings {
+  $margin: .8rem;
+  margin-top: $margin;
+  margin-left: $margin;
+
+    .name {
+      font-weight: bold;
+    }
+
+    input[type=checkbox] {
+      float: left;
+      margin-right: .3rem !important;
+    }
+
+    label {
+      margin: 0 !important;
+    }
+}

--- a/app/css/arethusa.scss
+++ b/app/css/arethusa.scss
@@ -5,6 +5,7 @@
 @import 'toaster';
 @import 'images';
 @import '../../vendor/highlight/styles/tomorrow';
+@import 'collected_plugin_settings';
 
 html, body {
   height: 100%;

--- a/app/js/arethusa.core/directives/collected_plugin_settings.js
+++ b/app/js/arethusa.core/directives/collected_plugin_settings.js
@@ -1,0 +1,15 @@
+"use strict";
+
+angular.module('arethusa.core').directive('collectedPluginSettings', [
+  'plugins',
+  function(plugins) {
+    return {
+      restrict: 'A',
+      scope: {},
+      link: function(scope, element, attrs) {
+        scope.plugins = plugins;
+      },
+      templateUrl: 'templates/arethusa.core/collected_plugin_settings.html'
+    };
+  }
+]);

--- a/app/js/arethusa.core/directives/global_settings_panel.js
+++ b/app/js/arethusa.core/directives/global_settings_panel.js
@@ -21,6 +21,12 @@ angular.module('arethusa.core').directive('globalSettingsPanel', [
             if (newVal) element.slideDown(); else element.slideUp();
           });
         });
+
+        scope.togglePluginSettings = togglePluginSettings;
+
+        function togglePluginSettings() {
+          scope.pluginSettingsVisible = !scope.pluginSettingsVisible;
+        }
       },
       templateUrl: 'templates/arethusa.core/global_settings_panel.html'
     };

--- a/app/templates/arethusa.core/collected_plugin_settings.html
+++ b/app/templates/arethusa.core/collected_plugin_settings.html
@@ -1,0 +1,9 @@
+<table class="plugin-settings">
+  <tr ng-repeat="plugin in plugins.all" ng-if="plugin.settings">
+    <td class="name">{{ plugin.displayName }}</td>
+    <td ng-repeat="setting in plugin.settings">
+      <span ng-if="setting.directive" dynamic-directive="{{ setting.directive }}"/>
+      <span ng-if="!setting.directive" plugin-setting orientation="left"/>
+    </td>
+  </tr>
+</table>

--- a/app/templates/arethusa.core/global_settings_panel.html
+++ b/app/templates/arethusa.core/global_settings_panel.html
@@ -22,5 +22,15 @@
         </div>
       </li>
     </ul>
+    <div ng-click="togglePluginSettings()" class="underline clickable">
+      Plugin Settings
+    </div>
+
+    <div
+      style="height: 250px"
+      class="fade"
+      ng-if="pluginSettingsVisible"
+      collected-plugin-settings>
+    </div>
   </div>
 </div>

--- a/app/templates/arethusa.core/global_settings_panel.html
+++ b/app/templates/arethusa.core/global_settings_panel.html
@@ -30,7 +30,6 @@
     </div>
 
     <div
-      style="height: 250px"
       class="fade"
       ng-if="pluginSettingsVisible"
       collected-plugin-settings>

--- a/app/templates/arethusa.core/global_settings_panel.html
+++ b/app/templates/arethusa.core/global_settings_panel.html
@@ -22,8 +22,11 @@
         </div>
       </li>
     </ul>
-    <div ng-click="togglePluginSettings()" class="underline clickable">
-      Plugin Settings
+
+    <div
+      ng-click="togglePluginSettings()"
+      translate="globalSettings.pluginSettings"
+      class="underline clickable">
     </div>
 
     <div

--- a/dist/i18n/de.json
+++ b/dist/i18n/de.json
@@ -160,7 +160,8 @@
     "colorizer": "Token einfärben nach",
     "layout": "Layout",
     "clickAction": "Klickverhalten",
-    "chunkMode": "Teilungsmodus"
+    "chunkMode": "Teilungsmodus",
+    "pluginSettings": "Plugin Einstellungen"
   },
   "navigator": {
     "goToFirst": "erster Abschnitt",

--- a/dist/i18n/en.json
+++ b/dist/i18n/en.json
@@ -160,7 +160,8 @@
     "colorizer": "Colorize tokens by",
     "layout": "Layout",
     "clickAction": "Click behaviour",
-    "chunkMode": "Chunk Mode"
+    "chunkMode": "Chunk Mode",
+    "pluginSettings": "Plugin Settings"
   },
   "navigator": {
     "goToFirst": "go to first chunk",


### PR DESCRIPTION
Adds the `collectedPluginSettings` directive which renders a table of all plugin settings.

The `globalSettingsPanel` is using this in a subsection of itself.

Styling needs more work - sliding it up and down for example. If animating height would only be a bit easier...


PS: Isn't it amazing how simple this is to do?!