### PR TITLE
Storing morphology preferences

### DIFF
--- a/app/js/arethusa.core/exit_handler.js
+++ b/app/js/arethusa.core/exit_handler.js
@@ -100,6 +100,7 @@ angular.module('arethusa.core').service('exitHandler', [
       });
 
       targetWin = targetWin || '_self';
+      triggerLeaveEvent();
       $window.open(exitUrl(), targetWin);
     }
 

--- a/app/js/arethusa.core/exit_handler.js
+++ b/app/js/arethusa.core/exit_handler.js
@@ -28,9 +28,16 @@ angular.module('arethusa.core').service('exitHandler', [
   "$window",
   "configurator",
   "$analytics",
-  function($location, $window, configurator, $analytics) {
+  '$rootScope',
+  function(
+    $location,
+    $window,
+    configurator,
+    $analytics,
+    $rootScope
+  ) {
+    var LEAVE_EVENT = 'exit:leave';
     var self = this;
-
 
     var conf = configurator.configurationFor('exitHandler') || {};
 
@@ -73,6 +80,9 @@ angular.module('arethusa.core').service('exitHandler', [
       return routeWithQueryParams(parsedRoute, queryParams);
     }
 
+    this.leave = leave;
+    this.onLeave = onLeave;
+    this.triggerLeaveEvent = triggerLeaveEvent;
 
     /**
      * @ngdoc function
@@ -84,13 +94,21 @@ angular.module('arethusa.core').service('exitHandler', [
      *
      * @param {string} [targetWin='_self'] The target window.
      */
-    this.leave = function(targetWin) {
+    function leave(targetWin) {
       $analytics.eventTrack('exit', {
         category: 'actions', label: 'exit'
       });
 
       targetWin = targetWin || '_self';
       $window.open(exitUrl(), targetWin);
-    };
+    }
+
+    function onLeave(cb) {
+      $rootScope.$on(LEAVE_EVENT, cb);
+    }
+
+    function triggerLeaveEvent() {
+      $rootScope.$broadcast(LEAVE_EVENT);
+    }
   }
 ]);

--- a/app/js/arethusa.core/navigator.js
+++ b/app/js/arethusa.core/navigator.js
@@ -8,6 +8,8 @@ angular.module('arethusa.core').service('navigator', [
   'globalSettings',
   function ($injector, configurator, $cacheFactory,
             keyCapture, $rootScope, globalSettings) {
+
+    var MOVE_EVENT = 'navigator:move';
     var self = this;
     var citeMapper;
     var context = {};
@@ -236,6 +238,7 @@ angular.module('arethusa.core').service('navigator', [
 
     this.updateState = function() {
       self.updateId();
+      triggerMoveEvent();
       self.state().replaceState(self.currentChunk());
     };
 
@@ -341,6 +344,17 @@ angular.module('arethusa.core').service('navigator', [
         currSents[i].changed = true;
       }
     };
+
+    this.onMove = onMove;
+
+    function onMove(cb) {
+      return $rootScope.$on(MOVE_EVENT, cb);
+    }
+
+    function triggerMoveEvent() {
+      $rootScope.$broadcast(MOVE_EVENT);
+    }
+
 
     // Probably could deregister/reregister that watch, but it doesn't hurt...
     $rootScope.$on('tokenChange',  self.markChunkChanged);

--- a/app/js/arethusa.core/saver.js
+++ b/app/js/arethusa.core/saver.js
@@ -9,8 +9,18 @@ angular.module('arethusa.core').service('saver', [
   '$window',
   'translator',
   '$analytics',
-  function(configurator, notifier, keyCapture, state,
-           $rootScope, $window, translator, $analytics) {
+  'exitHandler',
+  function(
+    configurator,
+    notifier,
+    keyCapture,
+    state,
+    $rootScope,
+    $window,
+    translator,
+    $analytics,
+    exitHandler
+  ) {
 
     var SUCCESS_EVENT = 'saveSuccess';
 
@@ -126,9 +136,17 @@ angular.module('arethusa.core').service('saver', [
     if (!state.debug) {
       // We need this when the user wants to reload, or move to another url
       // altogether.
-
-      $window.onbeforeunload = function() {
-        if (self.needsSave) { return translations.confirmNote(); }
+      // Due to crappy browser support we cannot trigger a leave event after the
+      // user does a confirmation of closing the application, which is something
+      // we are OK with for now: When the user does not want to save before he
+      // leaves, we will also do not trigger our event which will do further
+      // cleanups, caching etc.
+      $window.onbeforeunload = function(event) {
+        if (self.needsSave) {
+          return translations.confirmNote();
+        } else {
+          exitHandler.triggerLeaveEvent();
+        }
       };
 
       // We need this when a user is changing the url from within the application

--- a/app/js/arethusa.core/saver.js
+++ b/app/js/arethusa.core/saver.js
@@ -11,6 +11,9 @@ angular.module('arethusa.core').service('saver', [
   '$analytics',
   function(configurator, notifier, keyCapture, state,
            $rootScope, $window, translator, $analytics) {
+
+    var SUCCESS_EVENT = 'saveSuccess';
+
     var self = this;
     var conf, persisters;
 
@@ -62,6 +65,7 @@ angular.module('arethusa.core').service('saver', [
     // to handle the success notification better.
     function success(res) {
       self.needsSave = false;
+      $rootScope.$broadcast(SUCCESS_EVENT);
       notifier.success(translations.success());
     }
 
@@ -139,6 +143,10 @@ angular.module('arethusa.core').service('saver', [
       // When we really leave, clean up on onbeforeunload event
       $rootScope.$on('destroy', function() { $window.onbeforeunload = undefined; });
     }
+
+    this.onSuccess = function(cb) {
+      $rootScope.$on(SUCCESS_EVENT, cb);
+    };
 
     this.init = function(newPersisters) {
       defineKeyCaptures();

--- a/app/js/arethusa.morph/morph.js
+++ b/app/js/arethusa.morph/morph.js
@@ -8,8 +8,18 @@ angular.module('arethusa.morph').service('morph', [
   'morphLocalStorage',
   'commons',
   'saver',
-  function (state, configurator, plugins, globalSettings,
-            keyCapture, morphLocalStorage, commons, saver) {
+  'navigator',
+  function (
+    state,
+    configurator,
+    plugins,
+    globalSettings,
+    keyCapture,
+    morphLocalStorage,
+    commons,
+    saver,
+    navigator
+  ) {
     var self = this;
     this.name = 'morph';
 
@@ -54,7 +64,8 @@ angular.module('arethusa.morph').service('morph', [
       gloss: false,
       matchAll: true,
       preselect: false,
-      localStorage: true
+      localStorage: true,
+      storePreferences: true
     };
 
     function configure() {
@@ -64,7 +75,8 @@ angular.module('arethusa.morph').service('morph', [
         'mappings',
         'noRetrieval',
         'gloss',
-        'localStorage'
+        'localStorage',
+        'storePreferences'
       ];
 
       configurator.getConfAndDelegate(self, props);
@@ -715,15 +727,25 @@ angular.module('arethusa.morph').service('morph', [
 
     this.settings = [
       commons.setting('Expand Selected', 'expandSelection'),
+      commons.setting('Store Preferences', 'storePreferences'),
       commons.setting('Preselect', 'preselect', this.preselectToggled)
     ];
 
+    var shouldSavePreference;
     function afterSave() {
-      angular.forEach(state.tokens, savePreference);
+      shouldSavePreference = true;
     }
 
     function sortByPreference(string, forms) {
       return morphLocalStorage.sortByPreference(string, forms);
+    }
+
+    function savePreferences() {
+      if (shouldSavePreference && self.storePreferences) {
+        console.log('saving');
+        angular.forEach(state.tokens, savePreference);
+        shouldSavePreference = false;
+      }
     }
 
     function savePreference(token) {
@@ -733,6 +755,7 @@ angular.module('arethusa.morph').service('morph', [
     }
 
     saver.onSuccess(afterSave);
+    navigator.onMove(savePreferences);
 
     this.init = function () {
       abortOutstandingRequests();

--- a/app/js/arethusa.morph/morph.js
+++ b/app/js/arethusa.morph/morph.js
@@ -9,6 +9,7 @@ angular.module('arethusa.morph').service('morph', [
   'commons',
   'saver',
   'navigator',
+  'exitHandler',
   function (
     state,
     configurator,
@@ -18,7 +19,8 @@ angular.module('arethusa.morph').service('morph', [
     morphLocalStorage,
     commons,
     saver,
-    navigator
+    navigator,
+    exitHandler
   ) {
     var self = this;
     this.name = 'morph';
@@ -742,7 +744,6 @@ angular.module('arethusa.morph').service('morph', [
 
     function savePreferences() {
       if (shouldSavePreference && self.storePreferences) {
-        console.log('saving');
         angular.forEach(state.tokens, savePreference);
         shouldSavePreference = false;
       }
@@ -756,6 +757,7 @@ angular.module('arethusa.morph').service('morph', [
 
     saver.onSuccess(afterSave);
     navigator.onMove(savePreferences);
+    exitHandler.onLeave(savePreferences);
 
     this.init = function () {
       abortOutstandingRequests();

--- a/app/js/arethusa.morph/morph.js
+++ b/app/js/arethusa.morph/morph.js
@@ -7,8 +7,9 @@ angular.module('arethusa.morph').service('morph', [
   'keyCapture',
   'morphLocalStorage',
   'commons',
+  'saver',
   function (state, configurator, plugins, globalSettings,
-            keyCapture, morphLocalStorage, commons) {
+            keyCapture, morphLocalStorage, commons, saver) {
     var self = this;
     this.name = 'morph';
 
@@ -291,10 +292,14 @@ angular.module('arethusa.morph').service('morph', [
             // try to obtain additional info from the inventory
             getDataFromInventory(el);
           });
+          var str = analysisObj.string;
           var forms = analysisObj.forms;
           mergeDuplicateForms(forms[0], res);
           var newForms = makeUnique(res);
           arethusaUtil.pushAll(forms, newForms);
+
+          sortByPreference(str, forms);
+
           if (self.preselect) {
             preselectForm(forms[0], id);
           }
@@ -712,6 +717,22 @@ angular.module('arethusa.morph').service('morph', [
       commons.setting('Expand Selected', 'expandSelection'),
       commons.setting('Preselect', 'preselect', this.preselectToggled)
     ];
+
+    function afterSave() {
+      angular.forEach(state.tokens, savePreference);
+    }
+
+    function sortByPreference(string, forms) {
+      return morphLocalStorage.sortByPreference(string, forms);
+    }
+
+    function savePreference(token) {
+      if (token.morphology && token.morphology.postag) {
+        morphLocalStorage.addPreference(token.string, token.morphology);
+      }
+    }
+
+    saver.onSuccess(afterSave);
 
     this.init = function () {
       abortOutstandingRequests();

--- a/app/js/arethusa.morph/morph_local_storage.js
+++ b/app/js/arethusa.morph/morph_local_storage.js
@@ -3,13 +3,32 @@
 angular.module('arethusa.morph').service('morphLocalStorage', [
   'plugins',
   'arethusaLocalStorage',
-  function(plugins, arethusaLocalStorage) {
+  '_',
+  function(plugins, arethusaLocalStorage, _) {
+    var PREFERENCE_DELIMITER = ';;;';
+    var PREFERENCE_COUNT_DELIMITER = '@@@';
     var self = this;
 
     this.localStorageKey = 'morph.forms';
+    this.preferenceKey = 'morph.preference';
+
+    this.retriever = {
+      getData: getData,
+      abort: function() {}
+    };
+
+    this.addForm = addForm;
+    this.removeForm = removeForm;
+
+    this.addPreference = addPreference;
+    this.sortByPreference = sortByPreference;
 
     function key(k) {
       return self.localStorageKey + '.' + k;
+    }
+
+    function preferenceKey(k) {
+      return self.preferenceKey + '.' + k;
     }
 
 
@@ -22,16 +41,20 @@ angular.module('arethusa.morph').service('morphLocalStorage', [
       return arethusaLocalStorage.get(key(string)) || [];
     }
 
+    function retrievePreference(string) {
+      return arethusaLocalStorage.get(preferenceKey(string)) || '';
+    }
+
     function persist(string, value) {
       arethusaLocalStorage.set(key(string), value);
     }
 
-    this.retriever = {
-      getData: getData,
-      abort: function() {}
-    };
+    function persistPreference(string, value) {
+      return arethusaLocalStorage.set(preferenceKey(string), value);
 
-    this.addForm = function(string, form) {
+    }
+
+    function addForm(string, form) {
       // Check if we already stored info about this word,
       // if not add a need array to the store
       var forms = retrieve(string) || [];
@@ -41,9 +64,9 @@ angular.module('arethusa.morph').service('morphLocalStorage', [
       newForm.selected = false;
       forms.push(newForm);
       persist(string, forms);
-    };
+    }
 
-    this.removeForm = function(string, form) {
+    function removeForm(string, form) {
       var forms = retrieve(string);
       if (forms) {
         // find element and remove it, when it's present
@@ -55,6 +78,58 @@ angular.module('arethusa.morph').service('morphLocalStorage', [
         }
         persist(string, forms);
       }
-    };
+    }
+
+    function addPreference(string, form) {
+      var key = formToKey(form);
+      var counts = preferencesToCounts(string, key);
+      var counter = counts[key];
+      var newCount = counter ? counter + 1 : 1;
+      counts[key] = newCount;
+      var sortedCounts = toSortedArray(counts);
+      var toStore = _.map(sortedCounts, function(countArr) {
+        return countArr[0] + PREFERENCE_COUNT_DELIMITER + countArr[1];
+      }).join(PREFERENCE_COUNT_DELIMITER);
+
+      persistPreference(string, toStore);
+    }
+
+    function toSortedArray(counts) {
+      return _.map(counts, function(v, k) {
+        return [k, v];
+      }).sort(function(a, b) {
+        return a[1] < b[1];
+      });
+    }
+
+    function preferencesToCounts(string) {
+      var prefs = retrievePreference(string).split(PREFERENCE_DELIMITER);
+      return _.inject(_.filter(prefs), function(memo, pref) {
+        var parts = pref.split(PREFERENCE_COUNT_DELIMITER);
+        memo[parts[0]] = parseInt(parts[1]);
+        return memo;
+      }, {});
+    }
+
+    // Might be better to do this in an immutable way, but it works suprisingly well
+    function sortByPreference(string, forms) {
+      var counts = preferencesToCounts(string);
+      var selectors = _.inject(forms, function(memo, form) {
+        memo[formToKey(form)] = form;
+        return memo;
+      }, {});
+      _.forEachRight(toSortedArray(counts), function(counter) {
+        var form = selectors[counter[0]];
+        if (form) {
+          var i = forms.splice(forms.indexOf(i), 1);
+          forms.unshift(form);
+        }
+      });
+      return forms;
+    }
+
+    function formToKey(form) {
+      return form.lemma + '|-|' + form.postag;
+    }
   }
 ]);

--- a/app/js/arethusa.morph/morph_local_storage.js
+++ b/app/js/arethusa.morph/morph_local_storage.js
@@ -5,12 +5,12 @@ angular.module('arethusa.morph').service('morphLocalStorage', [
   'arethusaLocalStorage',
   '_',
   function(plugins, arethusaLocalStorage, _) {
-    var PREFERENCE_DELIMITER = ';;;';
-    var PREFERENCE_COUNT_DELIMITER = '@@@';
+    var PREFERENCE_DELIMITER = ';;';
+    var PREFERENCE_COUNT_DELIMITER = '@@';
     var self = this;
 
     this.localStorageKey = 'morph.forms';
-    this.preferenceKey = 'morph.preference';
+    this.preferenceKey = 'morph.prefs';
 
     this.retriever = {
       getData: getData,
@@ -118,10 +118,11 @@ angular.module('arethusa.morph').service('morphLocalStorage', [
         memo[formToKey(form)] = form;
         return memo;
       }, {});
+
       _.forEachRight(toSortedArray(counts), function(counter) {
         var form = selectors[counter[0]];
         if (form) {
-          var i = forms.splice(forms.indexOf(i), 1);
+          var i = forms.splice(forms.indexOf(form), 1);
           forms.unshift(form);
         }
       });

--- a/server/routes/examples.js
+++ b/server/routes/examples.js
@@ -40,7 +40,7 @@ function writeFile(req, res, addPath, ending) {
   req.on('end', function() {
     var p = docPath(req, addPath, ending);
     mkdirp(path.basename(p), function() {
-      fs.writeFile(path, prettify(doc, req), function() { res.end(); });
+      fs.writeFile(p, prettify(doc, req), function() { res.end(); });
     });
   });
 }


### PR DESCRIPTION
This is not an ideal solution to the problem, because it could never be done pure client-side only, but it's something that can be of immediate help to power users therefore it's OK to do it - we might consider throwing it away at some point though.


Uses `localStorage` to keep track of how often a user has selected a specific morphological form per string. This count is then used to rank/sort/order the results of the morphology service.

Storing is done only when the user specifically turns it on through the `morph` settings at the moment.
It takes place whenever the user has made a save of a passage and then triggers a `leave` (leaving the application) or `move` (going to another chunk) event.

The acquired data will be noisy, but most likely still be useful to the end-user.