### PR TITLE
DocumentResolver

### DIFF
--- a/app/js/arethusa.core/document_resolver.js
+++ b/app/js/arethusa.core/document_resolver.js
@@ -1,0 +1,31 @@
+"use strict";
+
+angular.module('arethusa.core').factory('DocumentResolver', [
+  'configurator',
+  '_',
+  function(configurator, _) {
+    return function DocumentResolver(conf) {
+      var resource = configurator.provideResource(conf.resource);
+
+      this.resolve = resolve;
+
+      function resolve(retrievers, onSuccessFnGenerator) {
+        resource.get().then(function(res) {
+          var docs = res.data;
+          _.forEach(docs, function(link, type) {
+            var retriever = getRetriever(retrievers, type);
+            if (retriever) {
+              var params = { doc: link };
+              retriever.get(params, onSuccessFnGenerator(retriever));
+            }
+          });
+        });
+      }
+
+      function getRetriever(retrievers, type) {
+        var name = conf.map[type];
+        if (name) return retrievers[name];
+      }
+    };
+  }
+]);

--- a/app/js/arethusa/treebank_retriever.js
+++ b/app/js/arethusa/treebank_retriever.js
@@ -217,8 +217,14 @@ angular.module('arethusa').factory('TreebankRetriever', [
         callback(parseDocument(json, docId));
       };
 
-      this.get = function (callback) {
-        resource.get().then(function (res) {
+      // Called with either one, or two params
+      this.get = function (params, callback) {
+        if (!callback) {
+          callback = params;
+          params = {};
+        }
+
+        resource.get(params).then(function (res) {
           self.parse(res.data, callback);
         });
       };

--- a/app/static/configs/resources/dev.json
+++ b/app/static/configs/resources/dev.json
@@ -1,4 +1,11 @@
 {
+  "fakeResolver" : {
+    "route" : "http://localhost:8081/resolve/:urn",
+    "params": [
+      "urn"
+    ]
+  },
+
   "fakePerseids" : {
     "route" : "http://74.70.97.104:8085/xml_server/:doc",
     "params" : [

--- a/app/static/configs/staging.json
+++ b/app/static/configs/staging.json
@@ -5,6 +5,12 @@
     "@include" : "layouts/perseids.json",
     "chunkParam" : "chunk",
     "auxConfPath": "/data/aux_configs/dist",
+    "resolver" : {
+      "resource" : "fakeResolver",
+      "map" : {
+        "treebank" : "TreebankRetriever"
+      }
+    },
     "retrievers" : {
       "TreebankRetriever" : {
         "resource" : "arethusaServerTreebank",

--- a/server/app.js
+++ b/server/app.js
@@ -9,6 +9,7 @@ var express = require('express'),
 
 var examples = require('./routes/examples');
 var fileBrowser = require('./routes/file_browser');
+var resolver = require('./routes/resolver');
 var base = path.resolve(__dirname + '/..');
 
 app.set('views', path.join(__dirname, 'views'));
@@ -18,7 +19,7 @@ app.set('view engine', 'html');
 app.use(morgan('dev'));
 app.use(require('connect-livereload')({ port: 35279 }));
 
-
+app.use('/resolve', resolver);
 app.use('/examples', examples);
 app.use('/browse', fileBrowser);
 app.use(express.static(base));

--- a/server/routes/resolver.js
+++ b/server/routes/resolver.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var express = require('express'),
+    router  = express.Router();
+
+router.get('/:urn', resolveUrn);
+
+function resolveUrn(req, res) {
+  res.json({
+    treebank: 'cat51.tb'
+  });
+}
+
+module.exports = router;


### PR DESCRIPTION
Adds the `DocumentResolver` factory, which is a pre-requisite to work with a more complex document retrieval process in the very near future, such as a CTS API.

When `state` is `init`'ed it does not directly communicate with its retrievers, when a document resolver is configured in a configuration file.

The call chain is then `state -> DocumentResolver -> Retrievers`, where the resolver is only responsible for retrieving document locations and passing these references off to the right retriever.

As the API we have to communicate with is not set in stone yet, a local mockup on our express server currently hardcodes a very simple response just to get up and running.