### PR TITLE
Add settings tab to `arethusaTabs`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -77,6 +77,7 @@ function arethusaSourceFiles() {
     "./vendor/uservoice/uservoice.min.js",
     "./vendor/angularJS-toaster/toaster.min.js",
     "./bower_components/angular-highlightjs/angular-highlightjs.min.js",
+    "./bower_components/angular-drag-and-drop-lists/angular-drag-and-drop-lists.min.js",
     "./vendor/highlight/highlight.pack.js",
   ];
 

--- a/app/css/arethusa.scss
+++ b/app/css/arethusa.scss
@@ -451,6 +451,34 @@ a:hover, a:focus {
   border-color: #aaaaaa;
 }
 
+ul[dnd-list]{
+  li {
+    background-color: #fff;
+    border: 1px solid #ddd;
+    border-top-right-radius: 4px;
+    border-top-left-radius: 4px;
+    display: block;
+    padding: 10px 15px;
+    margin-bottom: -1px;
+
+    @include transition(all 300ms ease-in-out);
+
+    &:hover {
+      cursor: -webkit-grab;
+    }
+
+    &.deactivated {
+      color: darken(darkgray, 20%);
+      background-color: $panel-bg;
+    }
+  }
+}
+
+/*.simpleDemo ul[dnd-list] li.selected {*/
+    /*background-color: #dff0d8;*/
+    /*color: #3c763d;*/
+/*}*/
+
 .top-bar, .top-bar-section .has-form, .top-bar-section ul, .top-bar-section li:not(.has-form) a:not(.button) {
   background: #4E6476;
 }

--- a/app/css/arethusa.scss
+++ b/app/css/arethusa.scss
@@ -495,10 +495,6 @@ a:hover, a:focus {
     }
   }
 }
-/*.simpleDemo ul[dnd-list] li.selected {*/
-    /*background-color: #dff0d8;*/
-    /*color: #3c763d;*/
-/*}*/
 
 .top-bar, .top-bar-section .has-form, .top-bar-section ul, .top-bar-section li:not(.has-form) a:not(.button) {
   background: #4E6476;

--- a/app/css/arethusa.scss
+++ b/app/css/arethusa.scss
@@ -451,29 +451,50 @@ a:hover, a:focus {
   border-color: #aaaaaa;
 }
 
-ul[dnd-list]{
-  li {
-    background-color: #fff;
-    border: 1px solid #ddd;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
-    display: block;
-    padding: 10px 15px;
-    margin-bottom: -1px;
+.arethusa-tabs {
+  p {
+    font-size: small;
+    font-style: italic;
+    padding: .5rem 1.5rem;
+  }
 
-    @include transition(all 300ms ease-in-out);
-
-    &:hover {
-      cursor: -webkit-grab;
+  ul[dnd-list]{
+    .dndDraggingSource {
+        display: none;
     }
 
-    &.deactivated {
-      color: darken(darkgray, 20%);
-      background-color: $panel-bg;
+    .dndPlaceholder {
+        display: block;
+        background-color: #ddd;
+        min-height: 42px;
+    }
+
+    > li {
+      position: relative;
+    }
+
+    li {
+      background-color: #fff;
+      border: 1px solid #ddd;
+      border-top-right-radius: 4px;
+      border-top-left-radius: 4px;
+      display: block;
+      padding: 10px 15px;
+      margin-bottom: -1px;
+
+      @include transition(all 300ms ease-in-out);
+
+      &:hover {
+        cursor: -webkit-grab;
+      }
+
+      &.deactivated {
+        color: darken(darkgray, 20%);
+        background-color: $panel-bg;
+      }
     }
   }
 }
-
 /*.simpleDemo ul[dnd-list] li.selected {*/
     /*background-color: #dff0d8;*/
     /*color: #3c763d;*/

--- a/app/js/arethusa.core.js
+++ b/app/js/arethusa.core.js
@@ -20,7 +20,8 @@ angular.module('arethusa.core', [
   'hljs',
   'mm.foundation',
   'LocalStorageModule',
-  'angularUUID2'
+  'angularUUID2',
+  'dndLists'
 ])
   .value('BASE_PATH', '..')
   .constant('_', window._);

--- a/app/js/arethusa.core/arethusa_tabs.js
+++ b/app/js/arethusa.core/arethusa_tabs.js
@@ -20,7 +20,7 @@ angular.module('arethusa.core').directive('arethusaTabs', [
       },
       link: function(scope, element, attrs) {
         var tabMap;
-        var activeTabs = getFromLocalStorage();
+        var tabConf = getFromLocalStorage();
 
         scope.plugins = plugins;
         scope.state = state;
@@ -63,15 +63,21 @@ angular.module('arethusa.core').directive('arethusaTabs', [
         }
 
         function activate(tab) {
-          activeTabs[tab.name] = true;
+          getConf(tab).active = true;
         }
 
         function deactivate(tab) {
-          activeTabs[tab.name] = false;
+          getConf(tab).active = false;
         }
 
         function isActive(tab) {
-          return activeTabs[tab.name];
+          return getConf(tab).active;
+        }
+
+        function getConf(tab) {
+          var conf = tabConf[tab.name];
+          if (!conf) conf = tabConf[tab.name] = {};
+          return conf;
         }
 
         function moveTab(i, event) {
@@ -121,7 +127,7 @@ angular.module('arethusa.core').directive('arethusaTabs', [
         }
 
         function setLocalStorage() {
-          arethusaLocalStorage.set(LOCAL_STORAGE_KEY, activeTabs);
+          arethusaLocalStorage.set(LOCAL_STORAGE_KEY, tabConf);
         }
       },
       templateUrl: 'templates/arethusa.core/arethusa_tabs.html'

--- a/app/js/arethusa.core/arethusa_tabs.js
+++ b/app/js/arethusa.core/arethusa_tabs.js
@@ -74,7 +74,11 @@ angular.module('arethusa.core').directive('arethusaTabs', [
           return activeTabs[tab.name];
         }
 
-        function moveTab(i) {
+        function moveTab(i, event) {
+          // The splice happens a little delayed, which means that for a short
+          // while we'll have one item in the list twice - let's hide it to
+          // avoid the flicker.
+          angular.element(event.toElement).hide();
           scope.list.splice(i, 1);
           updateVisibleTabs();
         }

--- a/app/js/arethusa.core/arethusa_tabs.js
+++ b/app/js/arethusa.core/arethusa_tabs.js
@@ -3,35 +3,42 @@
 angular.module('arethusa.core').directive('arethusaTabs', [
   'plugins',
   'state',
+  'arethusaLocalStorage',
   '_',
   function(
     plugins,
     state,
+    arethusaLocalStorage,
     _
   ) {
+    var LOCAL_STORAGE_KEY = 'tabsConfiguration';
+
     return {
       restrict: 'A',
       scope: {
         tabs: "=arethusaTabs"
       },
       link: function(scope, element, attrs) {
-        var activeTabs = {};
+        var activeTabs = getFromLocalStorage();
 
         scope.plugins = plugins;
         scope.state = state;
-
-        scope.$watch('tabs', function(tabs) {
-          if (!tabs) return;
-          activateSettings();
-          doInitialActivation();
-          updateVisibleTabs();
-          //createDragAndDropList(tabs);
-        });
 
         scope.moveTab = moveTab;
         scope.toggleTab = toggleTab;
 
         scope.isActive = isActive;
+
+        scope.$watch('tabs', init);
+
+        function init(tabs) {
+          if (!tabs) return;
+
+          activateSettings();
+          doInitialActivation();
+          updateVisibleTabs();
+        }
+
 
         function activate(tab) {
           activeTabs[tab.name] = true;
@@ -57,6 +64,7 @@ angular.module('arethusa.core').directive('arethusaTabs', [
             activate(tab);
           }
           updateVisibleTabs();
+          setLocalStorage();
         }
 
         function activateSettings() {
@@ -65,6 +73,8 @@ angular.module('arethusa.core').directive('arethusaTabs', [
 
         function doInitialActivation() {
           _.forEach(scope.tabs, function(tab) {
+            // If a setting is already present, don't do anything,
+            // otherwise activate it.
             if (!angular.isDefined(isActive(tab))) {
               activate(tab);
             }
@@ -75,6 +85,14 @@ angular.module('arethusa.core').directive('arethusaTabs', [
           scope.visibleTabs =_.filter(scope.tabs, function(tab) {
             return isActive(tab);
           });
+        }
+
+        function getFromLocalStorage() {
+          return arethusaLocalStorage.get(LOCAL_STORAGE_KEY) || {};
+        }
+
+        function setLocalStorage() {
+          arethusaLocalStorage.set(LOCAL_STORAGE_KEY, activeTabs);
         }
       },
       templateUrl: 'templates/arethusa.core/arethusa_tabs.html'

--- a/app/js/arethusa.core/arethusa_tabs.js
+++ b/app/js/arethusa.core/arethusa_tabs.js
@@ -3,15 +3,79 @@
 angular.module('arethusa.core').directive('arethusaTabs', [
   'plugins',
   'state',
-  function(plugins,state) {
+  '_',
+  function(
+    plugins,
+    state,
+    _
+  ) {
     return {
       restrict: 'A',
       scope: {
         tabs: "=arethusaTabs"
       },
       link: function(scope, element, attrs) {
+        var activeTabs = {};
+
         scope.plugins = plugins;
         scope.state = state;
+
+        scope.$watch('tabs', function(tabs) {
+          if (!tabs) return;
+          activateSettings();
+          doInitialActivation();
+          updateVisibleTabs();
+          //createDragAndDropList(tabs);
+        });
+
+        scope.moveTab = moveTab;
+        scope.toggleTab = toggleTab;
+
+        scope.isActive = isActive;
+
+        function activate(tab) {
+          activeTabs[tab.name] = true;
+        }
+
+        function deactivate(tab) {
+          activeTabs[tab.name] = false;
+        }
+
+        function isActive(tab) {
+          return activeTabs[tab.name];
+        }
+
+        function moveTab(i) {
+          scope.tabs.splice(i, 1);
+          updateVisibleTabs();
+        }
+
+        function toggleTab(tab) {
+          if (isActive(tab)) {
+            deactivate(tab);
+          } else {
+            activate(tab);
+          }
+          updateVisibleTabs();
+        }
+
+        function activateSettings() {
+          scope.showSettingsTab = true;
+        }
+
+        function doInitialActivation() {
+          _.forEach(scope.tabs, function(tab) {
+            if (!angular.isDefined(isActive(tab))) {
+              activate(tab);
+            }
+          });
+        }
+
+        function updateVisibleTabs() {
+          scope.visibleTabs =_.filter(scope.tabs, function(tab) {
+            return isActive(tab);
+          });
+        }
       },
       templateUrl: 'templates/arethusa.core/arethusa_tabs.html'
     };

--- a/app/templates/arethusa.core/arethusa_tabs.html
+++ b/app/templates/arethusa.core/arethusa_tabs.html
@@ -20,7 +20,7 @@
     <ul dnd-list="list">
       <li ng-repeat="item in list"
         dnd-draggable="item"
-        dnd-moved="moveTab($index)"
+        dnd-moved="moveTab($index, event)"
         dnd-effect-allowed="move"
         dnd-selected="toggleTab(item)"
         ng-class="{ deactivated: !isActive(item) }">

--- a/app/templates/arethusa.core/arethusa_tabs.html
+++ b/app/templates/arethusa.core/arethusa_tabs.html
@@ -17,16 +17,16 @@
 
     <p translate="tabs.helpText"></p>
 
-    <ul dnd-list="tabs">
-      <li ng-repeat="tab in tabs"
-        dnd-draggable="tab"
+    <ul dnd-list="list">
+      <li ng-repeat="item in list"
+        dnd-draggable="item"
         dnd-moved="moveTab($index)"
         dnd-effect-allowed="move"
-        dnd-selected="toggleTab(tab)"
-        ng-class="{ deactivated: !isActive(tab) }">
+        dnd-selected="toggleTab(item)"
+        ng-class="{ deactivated: !isActive(item) }">
         <div>
           <span>
-            {{ tab.displayName }}
+            {{ item.label }}
           </span>
         </div>
       </li>

--- a/app/templates/arethusa.core/arethusa_tabs.html
+++ b/app/templates/arethusa.core/arethusa_tabs.html
@@ -1,6 +1,6 @@
 <tabset>
   <tab
-    ng-repeat="pl in tabs"
+    ng-repeat="pl in visibleTabs"
     select="plugins.setActive(pl)"
     heading="{{ pl.displayName }}"
     active="plugins.isSelected(pl)">
@@ -9,6 +9,26 @@
       with-settings="true"
       ng-if="plugins.isActive(pl)">
     </plugin>
+  </tab>
+  <tab ng-if="showSettingsTab">
+    <tab-heading>
+      <i class="fi-widget rotate-on-hover"></i>
+    </tab-heading>
+
+    <ul dnd-list="tabs">
+      <li ng-repeat="tab in tabs"
+        dnd-draggable="tab"
+        dnd-moved="moveTab($index)"
+        dnd-effect-allowed="move"
+        dnd-selected="toggleTab(tab)"
+        ng-class="{ deactivated: !isActive(tab) }">
+        <div>
+          <span>
+            {{ tab.displayName }}
+          </span>
+        </div>
+      </li>
+    </ul>
   </tab>
 </tabset>
 

--- a/app/templates/arethusa.core/arethusa_tabs.html
+++ b/app/templates/arethusa.core/arethusa_tabs.html
@@ -1,4 +1,4 @@
-<tabset>
+<tabset class="arethusa-tabs">
   <tab
     ng-repeat="pl in visibleTabs"
     select="plugins.setActive(pl)"
@@ -14,6 +14,8 @@
     <tab-heading>
       <i class="fi-widget rotate-on-hover"></i>
     </tab-heading>
+
+    <p translate="tabs.helpText"></p>
 
     <ul dnd-list="tabs">
       <li ng-repeat="tab in tabs"

--- a/app/templates/arethusa.core/arethusa_tabs.html
+++ b/app/templates/arethusa.core/arethusa_tabs.html
@@ -24,11 +24,7 @@
         dnd-effect-allowed="move"
         dnd-selected="toggleTab(item)"
         ng-class="{ deactivated: !isActive(item) }">
-        <div>
-          <span>
-            {{ item.label }}
-          </span>
-        </div>
+        {{ item.label }}
       </li>
     </ul>
   </tab>

--- a/bower.json
+++ b/bower.json
@@ -2,10 +2,10 @@
   "name": "arethusa",
   "version": "0.2.5",
   "authors": [
-      "Gernot Höflechner",
-      "Christof Sirk",
-      "Robert Lichtensteiner",
-      "Bridget Almas"
+    "Gernot Höflechner",
+    "Christof Sirk",
+    "Robert Lichtensteiner",
+    "Bridget Almas"
   ],
   "description": "A backend-independent client-side annotation framework",
   "keywords": [
@@ -13,7 +13,10 @@
   ],
   "license": "MIT",
   "homepage": "https://github.com/latin-language-toolkit/arethusa",
-  "main": ["dist/arethusa_packages.min.js", "dist/arethusa.min.js"],
+  "main": [
+    "dist/arethusa_packages.min.js",
+    "dist/arethusa.min.js"
+  ],
   "ignore": [
     "app/css",
     "app/images",
@@ -52,7 +55,8 @@
     "angular-local-storage": "~0.1.5",
     "angular-uuid2": "",
     "lodash": "~2.4.1",
-    "stacktrace-js": "~0.6.4"
+    "stacktrace-js": "~0.6.4",
+    "angular-drag-and-drop-lists": "~1.2.0"
   },
   "resolutions": {
     "angular": "1.2.17",

--- a/dist/i18n/en.json
+++ b/dist/i18n/en.json
@@ -187,10 +187,13 @@
     "close" : "Close",
     "sendMessage" : "Type description of what you were doing here.",
     "sendHint" : "To send details of this error to us for investigation, please supply a brief description of what you were doing, check the 'Include Screenshot' checkbox to include the full error details, and click 'Next' to complete the steps to send. Then click 'Close' when done (or to skip sending)."
- 
+
   },
   "relocateHandler": {
     "title" : "Alternate Versions",
     "noLocations" : "N/A"
+  },
+  "tabs" : {
+    "helpText" : "Click to enable/disable a tab, or drag and drop to change the order or tabs."
   }
 }


### PR DESCRIPTION
Allows to re-order tabs and enable/disable them to save screen estate when things are not directly needed. It's not perfect, as these settings are controlled in an own tab, when it would be nicer to do it in the tabrow directly, but that opens up some UI question which we can avoid that way.

The drag and drop library will come in handy, once we work on the `confEditor` again.